### PR TITLE
uis: move uis docs into uis code

### DIFF
--- a/src/reference/config/ui-server.rst
+++ b/src/reference/config/ui-server.rst
@@ -1,14 +1,7 @@
 UI Server Configuration
 =======================
 
-Cylc UI Server can be configured using a ``jupyter_config.py``.
-
-Site level configuration, such as ``c.CylcUIServer.site_authorization`` should
-be defined in ``/etc/cylc/hub/jupyter_config.py``, or, alternatively, the
-environment variable ``CYLC_SITE_CONF_PATH``.
-User level configuration should be located in ``~/.cylc/hub/jupyter_config.py``.
-
-.. automodule:: cylc.uiserver
+.. automodule:: cylc.uiserver.app
 
 .. autoconfigurable:: cylc.uiserver.app.CylcUIServer
     :inherited-members: False


### PR DESCRIPTION
Bump the UIS docs into the UIS repo where they are easier to keep in check.